### PR TITLE
Correct purescript-profunctors dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-profunctor": "~0.0.2",
+    "purescript-profunctors": "~0.0.2",
     "purescript-distributive": "~0.3.0",
     "purescript-const": "~0.2.0",
     "purescript-identity": "~0.2.0",


### PR DESCRIPTION
This corrects the name of the purescript-profunctors dependency from "purescript-profunctor" to "purescript-profunctors". Without this change, trying to bower install purescript-lens as a dependency of ones project either results in bower trying to retrieve purescript-profunctor from a non-existant mankykitty archive, or bower creating both a "purescript-profuctor" and a "purescript-profunctors" directory. The latter occurs if another dependency itself depends on "purescript-profunctors" and leads to conflicts because both declare the same modules.