### PR TITLE
Fix warnings

### DIFF
--- a/src/Optic/Getter.purs
+++ b/src/Optic/Getter.purs
@@ -8,7 +8,7 @@ module Optic.Getter
 
   import Data.Const (getConst, Const(..))
   import Data.Functor.Contravariant ((>$<), Contravariant)
-  import Data.Profunctor (dimap, rmap, Profunctor)
+  import Data.Profunctor (dimap, Profunctor)
 
   import Optic.Types (Getting())
 

--- a/src/Optic/Laws/Lens.purs
+++ b/src/Optic/Laws/Lens.purs
@@ -8,7 +8,7 @@ module Optic.Laws.Lens where
   import Prelude (Eq, (&&), (==))
 
   -- | A valid `Lens` satisfies all three of the following laws.
-  validLens :: forall s a b. (Eq a, Eq s) => LensP s a -> s -> a -> a -> a -> Boolean
+  validLens :: forall s a. (Eq a, Eq s) => LensP s a -> s -> a -> a -> a -> Boolean
   validLens l s x y z = getSet l s
                      && setGet l s x
                      && setSet l s y z


### PR DESCRIPTION
The new PureScript compiler (0.7.6.) emits more warns than the old one.