### PR TITLE
Update .travis.yml to support PureScript 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 sudo: required
-node_js: 6
+node_js: 8
 install:
   - npm install -g bower
   - npm install


### PR DESCRIPTION
CI will fail on any attempted builds for PureScript 0.12 because the Travis Node version was too old. This updates it to Node 8.